### PR TITLE
Update kernel to 4.2.0.30-generic for the docker 1.12 training

### DIFF
--- a/train/labs/atp/scripts/ubuntu-14.04.py
+++ b/train/labs/atp/scripts/ubuntu-14.04.py
@@ -36,7 +36,7 @@ usermod -aG docker ubuntu
 # updates
 apt-get update
 apt-get -y upgrade
-apt-get install -y git tree jq linux-image-extra-4.2.0-23-generic linux-image-4.2.0.23-generic
+apt-get install -y git tree jq linux-image-extra-4.2.0-30-generic linux-image-4.2.0-30-generic
 
 # compose
 curl -L https://github.com/docker/compose/releases/download/1.6.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose

--- a/train/labs/docker/scripts/ubuntu-14.04.py
+++ b/train/labs/docker/scripts/ubuntu-14.04.py
@@ -111,7 +111,7 @@ sudo usermod -aG docker ubuntu
 # updates
 apt-get update
 apt-get -y upgrade
-apt-get install -y git tree jq linux-image-extra-4.2.0-23-generic linux-image-4.2.0.23-generic
+apt-get install -y git tree jq linux-image-extra-4.2.0-30-generic linux-image-4.2.0.30-generic
 
 {{dinfo}}
 reboot


### PR DESCRIPTION
There is a comment in the latest training material for 1.12:

> Instructor Note: Please ensure all student lab machines are using Linux kernel version 4.2.0-30-generic. Certain older kernel versions such as 4.2.0-23-generic contain a flaw whereby Java processes running in a Docker container will freeze and refuse to terminate. Not even a sudo kill -9 <pid> will shut down the process. The Docker container will refuse to shutdown and you won’t be able to restart the engine. Eventually the process becomes a zombie process and chews up all the VM resources, effectively destroying the machine.

This updates the kernel for the training example.
