### PR TITLE
Add ingress rules for each instance external IP

### DIFF
--- a/train/labs/datacenter/scripts/ubuntu-14.04.py
+++ b/train/labs/datacenter/scripts/ubuntu-14.04.py
@@ -22,7 +22,7 @@ def yn_prompt(query):
 install = yn_prompt("\nInstall UCP using 'non-interactive' mode on the master instance?")
 
 if install:
-    ucp = 'docker run --rm --name ucp -v /var/run/docker.sock:/var/run/docker.sock docker/ucp install --host-address $(curl http://169.254.169.254/latest/meta-data/public-hostname)'
+    ucp = 'docker run --rm --name ucp -v /var/run/docker.sock:/var/run/docker.sock docker/ucp install --host-address $(curl http://169.254.169.254/latest/meta-data/local-ipv4)'
 else:
     ucp = 'docker run --name ucp --rm -v /var/run/docker.sock:/var/run/docker.sock docker/ucp images'
 
@@ -46,7 +46,7 @@ service hostname restart
 sleep 5
 
 # docker
-curl -sSL https://get.docker.com/ | sh
+curl -SLf https://packages.docker.com/1.12/install.sh | repo=main sh
 
 # updates
 apt-get update
@@ -93,7 +93,7 @@ apt-get -y upgrade
 apt-get install -y git tree jq xfsprogs linux-image-extra-4.2.0-30-generic linux-image-4.2.0.30-generic
 
 # docker
-curl -sSL https://get.docker.com/ | sh
+curl -SLf https://packages.docker.com/1.12/install.sh | repo=main sh
 
 # docker compose
 curl -L https://github.com/docker/compose/releases/download/1.8.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
@@ -138,7 +138,7 @@ apt-get -y upgrade
 apt-get install -y git tree jq linux-image-extra-4.2.0-30-generic linux-image-4.2.0.30-generic
 
 # docker
-curl -sSL https://get.docker.com/ | sh
+curl -SLf https://packages.docker.com/1.12/install.sh | repo=main sh
 
 usermod -aG docker ubuntu
 


### PR DESCRIPTION
This commit fixes a problem with UCP 2.x installation which wouldn't allow an install to function properly. The problem is that the nodes need to be able to talk to one another via their externally-routable IP addresses. If you install using the internal VPC addresses, UCP 2.x creates redirects which it uses for the UI, which obviously can't use the internal IPs for communication. The solution is just to add each instance's externally-routable IP address to the ingress rules in the default security group (e.g. 54.145.54.145 instead of 10.0.3.18). This allows each UCP node to talk to one another via their external IPs, and the UI redirect links get valid, routable addresses.